### PR TITLE
backticks to variables in plotting call, rmarkdown dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,5 +26,6 @@ Imports: googlesheets,
     tibble,
     pander,
     fuzzyjoin,
-    ggplot2
+    ggplot2,
+    rmarkdown
 RoxygenNote: 6.1.0


### PR DESCRIPTION
added ggname function to enclose depVar in backticks when called in plotting functions (a NSE issue); added rmarkdown to requisite libraries